### PR TITLE
WIP: align Technique with uco-action:Technique metaclass (UCO 1.5.0)

### DIFF
--- a/scripts/validate_example_io.py
+++ b/scripts/validate_example_io.py
@@ -127,10 +127,16 @@ def validate(examples_graph, tech_names, tech_inputs, tech_outputs):
     mismatches = []
     warnings = []
 
-    action_class = URIRef(SOLVEIT_CORE_NS + "SolveitInvestigativeAction")
-    used_tech = URIRef(SOLVEIT_CORE_NS + "usedTechnique")
+    # Under the UCO 1.5.0 Technique metaclass model, an action states the
+    # technique it implements by rdf:type against the technique class. Any
+    # rdf:type value that is a known KB technique IRI counts as a technique
+    # used; nodes with no such type are not SOLVE-IT actions and are skipped.
+    for action in sorted(set(g.subjects(RDF.type, None)), key=str):
+        action_techniques = [t for t in g.objects(action, RDF.type)
+                             if str(t) in tech_names]
+        if not action_techniques:
+            continue
 
-    for action in sorted(g.subjects(RDF.type, action_class), key=str):
         names = list(g.objects(action, UCO_CORE_NAME))
         action_name = str(names[0]) if names else _short(str(action))
 
@@ -144,15 +150,9 @@ def validate(examples_graph, tech_names, tech_inputs, tech_outputs):
             for t in g.objects(res, RDF.type):
                 actual_output_types.add(str(t))
 
-        for tech_ref in g.objects(action, used_tech):
+        for tech_ref in action_techniques:
             tech_iri = str(tech_ref)
-            label = tech_names.get(tech_iri)
-
-            if label is None:
-                warnings.append(
-                    f"{action_name}: technique {_short(tech_iri)} not found in KB"
-                )
-                continue
+            label = tech_names[tech_iri]
 
             expected_inputs = tech_inputs.get(tech_iri, set())
             expected_outputs = tech_outputs.get(tech_iri, set())

--- a/scripts/validate_examples.py
+++ b/scripts/validate_examples.py
@@ -303,9 +303,14 @@ def validate_examples(project_root, defined_classes, defined_properties, propert
     UCO_ACTION = Namespace("https://ontology.unifiedcyberontology.org/uco/action/")
     combined_graph = g + ontology_graph  # query across both
 
-    action_class = SOLVEIT_CORE.SolveitInvestigativeAction
-    for action in g.subjects(RDF.type, action_class):
-        for technique_ref in g.objects(action, SOLVEIT_CORE.usedTechnique):
+    # Under the UCO 1.5.0 Technique metaclass model, a performed action states
+    # the technique it implements by rdf:type against the technique class,
+    # rather than through a usedTechnique property. A technique class is any
+    # node typed solveit-core:Technique in the examples or in the ontology.
+    technique_classes = set(combined_graph.subjects(RDF.type, SOLVEIT_CORE.Technique))
+
+    for action in set(g.subjects(RDF.type, None)):
+        for technique_ref in [t for t in g.objects(action, RDF.type) if t in technique_classes]:
             # Collect expected I/O classes from the technique definition
             expected_inputs = set()
             expected_outputs = set()

--- a/solve_it_analysis.ttl
+++ b/solve_it_analysis.ttl
@@ -18,9 +18,9 @@
 
 <https://ontology.solveit-df.org/solveit/analysis> rdf:type owl:Ontology ;
     owl:versionIRI <https://ontology.solveit-df.org/solveit/analysis/0.1.8> ;
-    owl:imports <https://ontology.unifiedcyberontology.org/uco/core/1.4.0> ,
-                <https://ontology.unifiedcyberontology.org/uco/observable/1.4.0> ,
-                <https://ontology.unifiedcyberontology.org/uco/analysis/1.4.0> ;
+    owl:imports <https://ontology.unifiedcyberontology.org/uco/core/1.5.0> ,
+                <https://ontology.unifiedcyberontology.org/uco/observable/1.5.0> ,
+                <https://ontology.unifiedcyberontology.org/uco/analysis/1.5.0> ;
     dcterms:title "SOLVE-IT Analysis Module"@en ;
     dcterms:description "Analytic results for SOLVE-IT digital forensics, including hypothesised events and forensic tool reports."@en ;
     dcterms:creator "SOLVE-IT Project" ;

--- a/solve_it_core.ttl
+++ b/solve_it_core.ttl
@@ -18,10 +18,10 @@
 
 <https://ontology.solveit-df.org/solveit/core> rdf:type owl:Ontology ;
     owl:versionIRI <https://ontology.solveit-df.org/solveit/core/0.1.8> ;
-    owl:imports <https://ontology.unifiedcyberontology.org/uco/core/1.4.0> ,
-                <https://ontology.unifiedcyberontology.org/uco/observable/1.4.0> ,
-                <https://ontology.unifiedcyberontology.org/uco/action/1.4.0> ,                
-                <https://ontology.caseontology.org/case/investigation/1.4.0> ,
+    owl:imports <https://ontology.unifiedcyberontology.org/uco/core/1.5.0> ,
+                <https://ontology.unifiedcyberontology.org/uco/observable/1.5.0> ,
+                <https://ontology.unifiedcyberontology.org/uco/action/1.5.0> ,
+                <https://ontology.caseontology.org/case/investigation/1.5.0> ,
                 <https://ontology.solveit-df.org/solveit/observable> ,
                 <https://ontology.solveit-df.org/solveit/analysis> ,
                 <https://ontology.solveit-df.org/solveit/tool-profile> ,
@@ -38,10 +38,21 @@
 #################################################################
 
 ###  SOLVE-IT Technique
+###
+###  Technique is a METACLASS, aligned with uco-action:Technique (UCO 1.5.0).
+###  Each SOLVE-IT technique (DFT-NNNN) is an *instance* of this class and is
+###  itself an owl:Class. UCO requires that a Technique instance be a subclass
+###  of uco-action:Action; SOLVE-IT satisfies this by having each root technique
+###  class declare rdfs:subClassOf solveit-core:SolveitInvestigativeAction,
+###  which is itself a subclass of case-investigation:InvestigativeAction.
+###
+###  Note: Technique is NOT a subclass of InvestigativeAction. That would make
+###  every catalogue entry a performed action. It is the *instances* of each
+###  technique class that are performed actions.
 solveit-core:Technique rdf:type owl:Class ;
-    rdfs:subClassOf case-investigation:InvestigativeAction ;
+    rdfs:subClassOf uco-action:Technique ;
     rdfs:label "SOLVE-IT Technique"@en ;
-    rdfs:comment "A digital forensic technique representing how one might achieve an objective by performing an action. Based on the SOLVE-IT knowledge base."@en .
+    rdfs:comment "A digital forensic technique representing how one might achieve an objective by performing an action. Based on the SOLVE-IT knowledge base. This class is a metaclass: its instances are owl:Class entities whose own instances are performed investigative actions."@en .
 
 ###  SOLVE-IT Weakness
 solveit-core:Weakness rdf:type owl:Class ;
@@ -62,10 +73,19 @@ solveit-core:Objective rdf:type owl:Class ;
     rdfs:comment "A goal or objective in a digital forensic investigation that can be achieved through one or more techniques."@en .
 
 ###  SOLVE-IT Investigative Action
+###
+###  The parent class of every SOLVE-IT technique class. A performed action is
+###  typed with the technique class(es) it implements; membership of this class
+###  then follows by inference, and with it membership of
+###  case-investigation:InvestigativeAction and uco-action:Action.
+###
+###  This class remains the anchor for occurrence-level SOLVE-IT properties —
+###  currently appliedMitigation — which describe what happened on one occasion
+###  rather than what the technique is in general.
 solveit-core:SolveitInvestigativeAction rdf:type owl:Class ;
     rdfs:subClassOf case-investigation:InvestigativeAction ;
     rdfs:label "SOLVE-IT Investigative Action"@en ;
-    rdfs:comment "A SOLVE-IT aware InvestigativeAction that links an investigative action to the SOLVE-IT technique(s) used (1..n via usedTechnique) and any mitigations applied (0..n via appliedMitigation) during its execution."@en .
+    rdfs:comment "An investigative action performed as an instance of one or more SOLVE-IT techniques, recording any mitigations applied on that occasion (0..n via appliedMitigation). The technique(s) used are expressed by rdf:type against the technique class(es), not by a separate property."@en .
 
 #################################################################
 #    Object Properties
@@ -101,11 +121,17 @@ solveit-core:includesTechnique rdf:type owl:ObjectProperty ;
     rdfs:label "includes technique"@en ;
     rdfs:comment "Links an Objective to Techniques that can be used to achieve it."@en .
 
+###  DEPRECATED as of the UCO 1.5.0 Technique metaclass alignment.
+###  A performed action now states the technique(s) it implements by rdf:type
+###  against the technique class(es), e.g.
+###      kb:action-01 a solveit-data:techniqueDFT-1002 .
+###  Retained so existing data continues to parse. Do not use in new data.
 solveit-core:usedTechnique rdf:type owl:ObjectProperty ;
+    owl:deprecated true ;
     rdfs:domain solveit-core:SolveitInvestigativeAction ;
     rdfs:range solveit-core:Technique ;
-    rdfs:label "used technique"@en ;
-    rdfs:comment "Links a SolveitInvestigativeAction to the SOLVE-IT Technique definition(s) that were executed. At least one technique must be specified (1..n)."@en .
+    rdfs:label "used technique (deprecated)"@en ;
+    rdfs:comment "DEPRECATED. Formerly linked a SolveitInvestigativeAction to the SOLVE-IT Technique definition(s) executed. Superseded by typing the action with the technique class itself, following the uco-action:Technique metaclass pattern."@en .
 
 solveit-core:appliedMitigation rdf:type owl:ObjectProperty ;
     rdfs:domain solveit-core:SolveitInvestigativeAction ;
@@ -141,17 +167,20 @@ solveit-core:techniqueDetails rdf:type owl:DatatypeProperty ;
     rdfs:label "technique details"@en ;
     rdfs:comment "Additional details about the technique."@en .
 
-solveit-core:hasCASEInputClass rdf:type owl:DatatypeProperty ;
+###  Input and output classes are referenced as IRIs, not as xsd:anyURI string
+###  literals. A literal is opaque: it cannot be followed by a reasoner, walked
+###  by a SPARQL property path, or checked by a validator for a typo.
+solveit-core:hasCASEInputClass rdf:type owl:ObjectProperty ;
     rdfs:domain solveit-core:Technique ;
-    rdfs:range xsd:anyURI ;
+    rdfs:range owl:Class ;
     rdfs:label "has CASE input class"@en ;
-    rdfs:comment "A CASE/UCO class IRI that represents an expected input to this technique. Multiple input classes can be specified (e.g., https://ontology.solveit-df.org/solveit/observable/WriteProtectedDeviceInterface)."@en .
+    rdfs:comment "A CASE/UCO class that represents an expected input to this technique. Multiple input classes can be specified (e.g., solveit-observable:WriteProtectedDeviceInterface)."@en .
 
-solveit-core:hasCASEOutputClass rdf:type owl:DatatypeProperty ;
+solveit-core:hasCASEOutputClass rdf:type owl:ObjectProperty ;
     rdfs:domain solveit-core:Technique ;
-    rdfs:range xsd:anyURI ;
+    rdfs:range owl:Class ;
     rdfs:label "has CASE output class"@en ;
-    rdfs:comment "A CASE/UCO class IRI that represents an output of this technique. Multiple output classes can be specified (e.g., https://ontology.unifiedcyberontology.org/uco/observable/Image)."@en .
+    rdfs:comment "A CASE/UCO class that represents an output of this technique. Multiple output classes can be specified (e.g., uco-observable:Image)."@en .
 
 #################################################################
 #    Data Properties - Weakness

--- a/solve_it_core_shapes.ttl
+++ b/solve_it_core_shapes.ttl
@@ -1,0 +1,36 @@
+@prefix : <https://ontology.solveit-df.org/solveit/core/shapes/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix solveit-core: <https://ontology.solveit-df.org/solveit/core/> .
+@base <https://ontology.solveit-df.org/solveit/core/shapes/> .
+
+#################################################################
+#    SOLVE-IT Core SHACL Shapes
+#    Validation constraints for the SOLVE-IT core vocabulary.
+#    Companion to solve_it_observable_shapes.ttl; load alongside the
+#    ontology (as a supplemental graph) when validating data.
+#################################################################
+
+#################################################################
+#    SolveitInvestigativeAction Shape
+#################################################################
+
+:SolveitInvestigativeActionShape a sh:NodeShape ;
+    sh:targetClass solveit-core:SolveitInvestigativeAction ;
+    rdfs:label "SOLVE-IT Investigative Action Shape"@en ;
+    rdfs:comment "Enforces the cardinality solve_it_core.ttl states in prose: a SolveitInvestigativeAction links to at least one SOLVE-IT technique (1..n via usedTechnique)."@en ;
+    sh:property [
+        sh:path solveit-core:usedTechnique ;
+        sh:minCount 1 ;
+        sh:nodeKind sh:IRI ;
+        sh:message "A SolveitInvestigativeAction must reference at least one SOLVE-IT technique via usedTechnique (1..n)."@en ;
+    ] .
+
+# Note: usedTechnique's range (solveit-core:Technique) is asserted as an
+# OWL rdfs:range in solve_it_core.ttl but is deliberately NOT enforced
+# here as sh:class. Data graphs commonly reference the technique
+# individual as an external node (e.g. solveit-data:techniqueDFT-NNNN)
+# without restating its type, so a class check would fail well-formed
+# data. The shape requires an IRI value instead. A stricter range shape
+# is a candidate once a convention is agreed for declaring (or importing)
+# the referenced Technique individuals.

--- a/solve_it_core_shapes.ttl
+++ b/solve_it_core_shapes.ttl
@@ -1,6 +1,8 @@
 @prefix : <https://ontology.solveit-df.org/solveit/core/shapes/> .
 @prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
 @prefix solveit-core: <https://ontology.solveit-df.org/solveit/core/> .
 @base <https://ontology.solveit-df.org/solveit/core/shapes/> .
 
@@ -14,23 +16,57 @@
 #################################################################
 #    SolveitInvestigativeAction Shape
 #################################################################
+#
+#    RETIRED at the UCO 1.5.0 Technique metaclass alignment.
+#
+#    The former shape required minCount 1 on solveit-core:usedTechnique.
+#    Under the metaclass model an action states its technique(s) by rdf:type
+#    against the technique class(es), and every technique class descends from
+#    solveit-core:SolveitInvestigativeAction. A node therefore cannot be a
+#    member of this class without carrying at least one technique type, so
+#    the constraint has no violating state left to detect.
+#
+#    Restating it would require a sh:sparql constraint counting rdf:type
+#    values that are SOLVE-IT technique classes, which buys nothing.
+#
+#    The target class itself remains available for future occurrence-level
+#    constraints (for example on appliedMitigation).
+#
+#    Note on targeting: sh:targetClass selects SHACL instances, which follow
+#    rdf:type then rdfs:subClassOf* . An action typed only with its technique
+#    class is therefore still selected by a shape targeting
+#    solveit-core:SolveitInvestigativeAction, with no reasoner required.
+#################################################################
 
-:SolveitInvestigativeActionShape a sh:NodeShape ;
-    sh:targetClass solveit-core:SolveitInvestigativeAction ;
-    rdfs:label "SOLVE-IT Investigative Action Shape"@en ;
-    rdfs:comment "Enforces the cardinality solve_it_core.ttl states in prose: a SolveitInvestigativeAction links to at least one SOLVE-IT technique (1..n via usedTechnique)."@en ;
+#################################################################
+#    Technique Shape
+#################################################################
+#
+#    A SOLVE-IT technique is simultaneously an instance of the Technique
+#    metaclass and an owl:Class. Both facts must be asserted, and the class
+#    must sit under SolveitInvestigativeAction so that its instances are
+#    investigative actions. UCO states this convention in prose because OWL 2
+#    has no axiom for "instances of this metaclass are subclasses of X", so it
+#    is checked here instead.
+
+:TechniqueShape a sh:NodeShape ;
+    sh:targetClass solveit-core:Technique ;
+    rdfs:label "SOLVE-IT Technique Shape"@en ;
+    rdfs:comment "Checks that each SOLVE-IT technique is declared as an owl:Class and is placed under solveit-core:SolveitInvestigativeAction, directly or through a parent technique."@en ;
     sh:property [
-        sh:path solveit-core:usedTechnique ;
+        sh:path rdf:type ;
+        sh:hasValue owl:Class ;
+        sh:message "A SOLVE-IT technique must also be declared an owl:Class, so that performed actions can be typed with it."@en ;
+    ] ;
+    sh:property [
+        sh:path rdfs:subClassOf ;
         sh:minCount 1 ;
         sh:nodeKind sh:IRI ;
-        sh:message "A SolveitInvestigativeAction must reference at least one SOLVE-IT technique via usedTechnique (1..n)."@en ;
+        sh:message "A SOLVE-IT technique class must have at least one rdfs:subClassOf — either its parent technique, or solveit-core:SolveitInvestigativeAction for a root technique."@en ;
+    ] ;
+    sh:property [
+        sh:path solveit-core:techniqueID ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:message "A SOLVE-IT technique must have exactly one techniqueID."@en ;
     ] .
-
-# Note: usedTechnique's range (solveit-core:Technique) is asserted as an
-# OWL rdfs:range in solve_it_core.ttl but is deliberately NOT enforced
-# here as sh:class. Data graphs commonly reference the technique
-# individual as an external node (e.g. solveit-data:techniqueDFT-NNNN)
-# without restating its type, so a class check would fail well-formed
-# data. The shape requires an IRI value instead. A stricter range shape
-# is a candidate once a convention is agreed for declaring (or importing)
-# the referenced Technique individuals.

--- a/solve_it_examples/core_classes_examples.ttl
+++ b/solve_it_examples/core_classes_examples.ttl
@@ -193,7 +193,25 @@ solveit-core:ASTM_INCOMP rdf:type solveit-core:ASTMErrorCategory .
 
 :searchresults-e5f67890-abcd-ef01-2345-555566667777 rdf:type solveit-observable:KeywordSearchResultSet ;
     rdfs:label "Keyword search results"@en ;
-    uco-core:description "1,247 hits across 312 files from indexed keyword search" .
+    uco-core:description "1,247 hits across 312 files from indexed keyword search" ;
+    solveit-observable:hasSearchResult :hit-07890123-def0-1234-5678-777788889991 ;
+    solveit-observable:hasSearchResult :hit-07890123-def0-1234-5678-777788889992 ;
+    solveit-observable:hasSearchResult :hit-07890123-def0-1234-5678-777788889993 .
+
+###  Individual hits within the result set. Three are shown here as a
+###  sample; the full set contains 1,247. Because the search was indexed,
+###  each hit is already resolved to a file rather than a raw byte offset.
+:hit-07890123-def0-1234-5678-777788889991 rdf:type solveit-observable:KeywordSearchResult ;
+    rdfs:label "Hit: 'Whitfield' in \\Users\\jsmith\\Documents\\contacts.docx"@en ;
+    uco-core:description "Match on a suspect alias from the case-specific wordlist" .
+
+:hit-07890123-def0-1234-5678-777788889992 rdf:type solveit-observable:KeywordSearchResult ;
+    rdfs:label "Hit: '14 Marlow Road' in \\Users\\jsmith\\AppData\\Local\\Microsoft\\Outlook\\archive.pst"@en ;
+    uco-core:description "Match on a case address, located in an email store" .
+
+:hit-07890123-def0-1234-5678-777788889993 rdf:type solveit-observable:KeywordSearchResult ;
+    rdfs:label "Hit: 'Whitfield' in \\Users\\jsmith\\Downloads\\invoice_0342.pdf"@en ;
+    uco-core:description "Second match on the same alias in a different file" .
 
 ###  SolveitInvestigativeAction: Indexed Keyword Search with Case-Specific Wordlists
 ###

--- a/solve_it_observable.ttl
+++ b/solve_it_observable.ttl
@@ -18,8 +18,8 @@
 
 <https://ontology.solveit-df.org/solveit/observable> rdf:type owl:Ontology ;
     owl:versionIRI <https://ontology.solveit-df.org/solveit/observable/0.1.8> ;
-    owl:imports <https://ontology.unifiedcyberontology.org/uco/core/1.4.0> ,
-                <https://ontology.unifiedcyberontology.org/uco/observable/1.4.0> ,
+    owl:imports <https://ontology.unifiedcyberontology.org/uco/core/1.5.0> ,
+                <https://ontology.unifiedcyberontology.org/uco/observable/1.5.0> ,
                 <https://ontology.solveit-df.org/solveit/observable/acquisition> ,
                 <https://ontology.solveit-df.org/solveit/observable/timeline> ,
                 <https://ontology.solveit-df.org/solveit/observable/search> ;

--- a/solve_it_observable_acquisition.ttl
+++ b/solve_it_observable_acquisition.ttl
@@ -16,7 +16,7 @@
 
 <https://ontology.solveit-df.org/solveit/observable/acquisition> rdf:type owl:Ontology ;
     owl:versionIRI <https://ontology.solveit-df.org/solveit/observable/acquisition/0.1.8> ;
-    owl:imports <https://ontology.unifiedcyberontology.org/uco/observable/1.4.0> ;
+    owl:imports <https://ontology.unifiedcyberontology.org/uco/observable/1.5.0> ;
     dcterms:title "SOLVE-IT Observable Acquisition Module"@en ;
     dcterms:description "Classes for forensic data acquisition including forensic images, live captures, and extraction methods."@en ;
     dcterms:creator "SOLVE-IT Project" ;

--- a/solve_it_observable_search.ttl
+++ b/solve_it_observable_search.ttl
@@ -14,7 +14,7 @@
 
 <https://ontology.solveit-df.org/solveit/observable/search> rdf:type owl:Ontology ;
     owl:versionIRI <https://ontology.solveit-df.org/solveit/observable/search/0.1.8> ;
-    owl:imports <https://ontology.unifiedcyberontology.org/uco/observable/1.4.0> ;
+    owl:imports <https://ontology.unifiedcyberontology.org/uco/observable/1.5.0> ;
     dcterms:title "SOLVE-IT Observable Search Module"@en ;
     dcterms:description "Classes for keyword search, indexing, and file system analysis."@en ;
     dcterms:creator "SOLVE-IT Project" ;

--- a/solve_it_observable_timeline.ttl
+++ b/solve_it_observable_timeline.ttl
@@ -14,7 +14,7 @@
 
 <https://ontology.solveit-df.org/solveit/observable/timeline> rdf:type owl:Ontology ;
     owl:versionIRI <https://ontology.solveit-df.org/solveit/observable/timeline/0.1.8> ;
-    owl:imports <https://ontology.unifiedcyberontology.org/uco/observable/1.4.0> ;
+    owl:imports <https://ontology.unifiedcyberontology.org/uco/observable/1.5.0> ;
     dcterms:title "SOLVE-IT Observable Timeline Module"@en ;
     dcterms:description "Classes for forensic timeline analysis including timestamps, timeline entries, and temporal ordering."@en ;
     dcterms:creator "SOLVE-IT Project" ;

--- a/solve_it_sqlite.ttl
+++ b/solve_it_sqlite.ttl
@@ -16,8 +16,8 @@
 
 <https://ontology.solveit-df.org/solveit/observable/sqlite> rdf:type owl:Ontology ;
     owl:versionIRI <https://ontology.solveit-df.org/solveit/observable/sqlite/0.1.8> ;
-    owl:imports <https://ontology.unifiedcyberontology.org/uco/core/1.4.0> ,
-                <https://ontology.unifiedcyberontology.org/uco/observable/1.4.0> ;
+    owl:imports <https://ontology.unifiedcyberontology.org/uco/core/1.5.0> ,
+                <https://ontology.unifiedcyberontology.org/uco/observable/1.5.0> ;
     dcterms:title "SOLVE-IT SQLite Module"@en ;
     dcterms:description "SQLite database structural representation for digital forensic analysis, including logical structure (tables, schemas, records), physical structure (pages), and WAL/journal representations."@en ;
     dcterms:creator "SOLVE-IT Project" ;

--- a/solve_it_tool_profile.ttl
+++ b/solve_it_tool_profile.ttl
@@ -20,9 +20,9 @@
 
 <https://ontology.solveit-df.org/solveit/tool-profile> rdf:type owl:Ontology ;
     owl:versionIRI <https://ontology.solveit-df.org/solveit/tool-profile/0.1.8> ;
-    owl:imports <https://ontology.unifiedcyberontology.org/uco/core/1.4.0> ,
-                <https://ontology.unifiedcyberontology.org/uco/tool/1.4.0> ,
-                <https://ontology.unifiedcyberontology.org/uco/observable/1.4.0> ,
+    owl:imports <https://ontology.unifiedcyberontology.org/uco/core/1.5.0> ,
+                <https://ontology.unifiedcyberontology.org/uco/tool/1.5.0> ,
+                <https://ontology.unifiedcyberontology.org/uco/observable/1.5.0> ,
                 <https://ontology.solveit-df.org/solveit/core> ;
     dcterms:title "SOLVE-IT Tool Profile Module"@en ;
     dcterms:description "Capability profiles for forensic tools, enabling conditional mitigation declarations that are version-specific and attributable."@en ;

--- a/solve_it_weakness_assessment.ttl
+++ b/solve_it_weakness_assessment.ttl
@@ -20,9 +20,9 @@
 
 <https://ontology.solveit-df.org/solveit/weakness-assessment> rdf:type owl:Ontology ;
     owl:versionIRI <https://ontology.solveit-df.org/solveit/weakness-assessment/0.1.8> ;
-    owl:imports <https://ontology.unifiedcyberontology.org/uco/core/1.4.0> ,
-                <https://ontology.unifiedcyberontology.org/uco/analysis/1.4.0> ,
-                <https://ontology.unifiedcyberontology.org/uco/identity/1.4.0> ,
+    owl:imports <https://ontology.unifiedcyberontology.org/uco/core/1.5.0> ,
+                <https://ontology.unifiedcyberontology.org/uco/analysis/1.5.0> ,
+                <https://ontology.unifiedcyberontology.org/uco/identity/1.5.0> ,
                 <https://ontology.solveit-df.org/solveit/core> ;
     dcterms:title "SOLVE-IT Weakness Assessment Module"@en ;
     dcterms:description "Risk-based weakness assessment providing Likelihood x Impact (ISO 31000) and FMEA/RPN scoring frameworks for SOLVE-IT weaknesses."@en ;


### PR DESCRIPTION
**Draft — examples are still to do. Not ready to merge.**

UCO 1.5.0 (released 24 July 2026) introduces `uco-action:Technique` as a metaclass: a Technique instance is itself an `owl:Class` that is a subclass of `uco-action:Action`. This moves SOLVE-IT onto that pattern. A performed action now states which technique it implements by `rdf:type`, rather than through a `usedTechnique` link.

Companion PR: SOLVE-IT-DF/solve-it#550 (knowledge base generator).

## The model

| Level | Term | Performed? |
|---|---|---|
| Metaclass | `solveit-core:Technique` → `uco-action:Technique` | no |
| Class | `solveit-data:techniqueDFT-NNNN` | no |
| Individual | a performed action | yes |

## Changes

**`solve_it_core.ttl`**
- `Technique` now subclasses `uco-action:Technique` instead of `case-investigation:InvestigativeAction`. The old axiom sat on the metaclass, so it applied to the catalogue entries and made each one a performed action. It is now also *required*: `core:UcoType` is `owl:disjointWith core:UcoThing`, so keeping both parents would make every DFT-NNNN an instance of two disjoint classes.
- `SolveitInvestigativeAction` **kept**, and is now the parent of every technique class. It remains the anchor for occurrence-level properties, so `appliedMitigation` needs no change — its domain is satisfied by inference.
- `usedTechnique` marked `owl:deprecated`, retained so existing data parses.
- `hasCASEInputClass` / `hasCASEOutputClass`: datatype property with range `xsd:anyURI` → object property with range `owl:Class`. A class IRI inside a string literal cannot be followed by a reasoner, walked by a SPARQL property path, or checked for a typo.

**`solve_it_core_shapes.ttl`**
- Retired `SolveitInvestigativeActionShape`. It required `minCount 1` on `usedTechnique`; under the metaclass model an action cannot belong to the class without carrying a technique type, so there is no violating state left to detect.
- Added `TechniqueShape`, checking what OWL cannot express: that each technique is also declared `owl:Class` and has an `rdfs:subClassOf`.

**Imports** — all UCO and CASE imports moved 1.4.0 → 1.5.0 across 9 files (19 imports). A partial bump does not work: `uco-action` 1.5.0 itself imports `uco-core` 1.5.0, which would put two versionIRIs of the same ontology in one closure. CASE 1.5.0 was released alongside UCO 1.5.0 and imports `uco-action` 1.5.0, so it is the matching release.

**Validators** now discover actions by `rdf:type` against technique classes instead of by `usedTechnique`.

## Verification

- UCO 1.5.0 is purely additive over 1.4.0: 1,174 → 1,177 declared terms, nothing removed, nothing retyped, no domain or range changed, no SHACL constraint removed. UCO asserts `owl:backwardCompatibleWith action:1.4.0`.
- Every external UCO/CASE term SOLVE-IT references resolves in 1.5.0.
- Running **UCO 1.5.0's own SHACL shapes** over the regenerated knowledge base: zero violations, zero warnings. The 667 results are all `sh:Info`, the pre-existing "UcoThings are suggested to end with a UUID" advisory, which is present in 1.4.0 too.
- Negative control: removing one `rdfs:subClassOf` from `techniqueDFT-1002` produces exactly the two expected violations, confirming the shapes are genuinely targeting SOLVE-IT techniques.
- `validate_ontology.py` and `validate_examples.py` pass.

## Still to do — why this is a draft

The **14 example actions across six files** in `solve_it_examples/` have not been migrated and still use `usedTechnique`. Until they are, `validate_example_io.py` discovers zero actions and its pass is vacuous, not real.

| File | Actions |
|---|---|
| `search_examples.ttl` | 5 |
| `sorted_timeline_examples.ttl` | 4 |
| `core_classes_examples.ttl` | 3 |
| `timeline_sequence_examples.ttl` | 2 |
| `timeline_resolution_examples.ttl` | 2 |
| `triaged_devices_examples.ttl` | 1 |

## Notes for review

- This branch was cut from `add-core-shacl-shapes`, which had never been PR'd, so it carries that commit too. The result is that one commit adds a SHACL shape and the next retires it — honest history, but worth knowing when reading the diff.
- Merge order: the hourly `generate-knowledge-base` workflow checks out `solve-it` at `ref: main`, so merging the companion PR switches the published KB to IRI-valued CASE classes immediately. Merging this one first keeps the schema ahead of the data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)